### PR TITLE
altair v4.2.1 without jsonschema upper bound

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python >=3.7
     - entrypoints
     - jinja2
-    - jsonschema >=4.17.0
+    - jsonschema >=4.5.0
     - numpy >=0.18
     - pandas >=0.18
     - toolz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python >=3.7
     - entrypoints
     - jinja2
-    - jsonschema >=3.0,<4.17
+    - jsonschema >=3.0
     - numpy >=0.18
     - pandas >=0.18
     - toolz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python >=3.7
     - entrypoints
     - jinja2
-    - jsonschema >=4.3.0
+    - jsonschema >=4.17.0
     - numpy >=0.18
     - pandas >=0.18
     - toolz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "altair" %}
-{% set version = "4.2.0" %}
+{% set version = "4.2.1" %}
 
 
 package:
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/altair-{{ version }}.tar.gz
-  sha256: d87d9372e63b48cd96b2a6415f0cf9457f50162ab79dc7a31cd7e024dd840026
+  sha256: 4939fd9119c57476bf305af9ca0bd1aa7779b2450b874d3623660e879d0fcad1
 
 build:
-  number: 2
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python >=3.7
     - entrypoints
     - jinja2
-    - jsonschema >=3.0
+    - jsonschema >=4.3.0
     - numpy >=0.18
     - pandas >=0.18
     - toolz


### PR DESCRIPTION
Closes #42

This PR removes the upper bound on jsonschema for 4.2.1. This PR should merged instead of #42.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
