### PR TITLE
Install anywidget with altair-all

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 0ce8c2e66546cb327e5f2d7572ec0e7c6feece816203215613962f0ec1d76a82
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:
@@ -64,6 +64,7 @@ outputs:
         - pyarrow >=11
         - vegafusion >=1.6.6
         - vegafusion-python-embed
+        - anywidget >=0.9.0
         - {{ pin_subpackage('altair', exact=True) }}
         - altair_tiles >=0.3.0
       test:


### PR DESCRIPTION
`anywidget` is part of our [`all` dependency group](https://github.com/vega/altair/blob/17968ea95489cc88de647381d3d1974b49dab88e/pyproject.toml#L57-L66) in `pypi` as it is required for jupyterchart, but it wasn't included here for some reason (I probably missed it initially).

---

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
