### PR TITLE
Restrict vegafusion from installing 2rc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 0ce8c2e66546cb327e5f2d7572ec0e7c6feece816203215613962f0ec1d76a82
 
 build:
-  number: 2
+  number: 3
   noarch: python
 
 outputs:
@@ -62,7 +62,7 @@ outputs:
       run:
         - vl-convert-python >=1.6.0
         - pyarrow >=11
-        - vegafusion >=1.6.6, <2
+        - vegafusion >=1.6.6, <1.7
         - vegafusion-python-embed
         - anywidget >=0.9.0
         - {{ pin_subpackage('altair', exact=True) }}


### PR DESCRIPTION
It seems like the previous fix of <2 was not enough. I'm unsure how conda treats rc versions (maybe 2rc < 2?), but restricting vegafusion to max 1.7 will hopefully prevent the 2rc version from being installed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
