### PR TITLE
v5.5.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,4 +5,4 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "altair-split" %}
-{% set version = "5.4.1" %}
+{% set version = "5.5.0" %}
 
 
 package:
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/altair/altair-{{ version }}.tar.gz
-  sha256: 0ce8c2e66546cb327e5f2d7572ec0e7c6feece816203215613962f0ec1d76a82
+  sha256: d960ebe6178c56de3855a68c47b516be38640b73fb3b5111c2a9ca90546dd73d
 
 build:
-  number: 3
+  number: 0
   noarch: python
 
 outputs:
@@ -21,17 +21,17 @@ outputs:
       noarch: python
     requirements:
       host:
-        - python >=3.8, <3.13
+        - python >=3.9
         - pip
         - hatchling
       run:
         - packaging
-        - python >=3.8, <3.13
+        - python >=3.9
         - importlib-metadata
         - typing-extensions >=4.10.0
         - jinja2
         - jsonschema >=3.0
-        - narwhals >=1.1.0
+        - narwhals >=1.14.2
     test:
       source_files:
         - altair
@@ -58,12 +58,11 @@ outputs:
       noarch: python
     requirements:
       host:
-        - python >=3.8, <3.13
+        - python >=3.9
       run:
-        - vl-convert-python >=1.6.0
+        - vl-convert-python >=1.7.0
         - pyarrow >=11
-        - vegafusion >=1.6.6, <1.7
-        - vegafusion-python-embed
+        - vegafusion >=2.0.0rc1
         - anywidget >=0.9.0
         - {{ pin_subpackage('altair', exact=True) }}
         - altair_tiles >=0.3.0


### PR DESCRIPTION
Bump to 5.5.0, update constraints on deps.

Closes https://github.com/conda-forge/altair-feedstock/issues/59, bump VegaFusion lower bound to v2 so that `vegafusion-python-embedded` isn't needed anymore.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

